### PR TITLE
Add HLTrigger results used by CTPPS Pixel DQM 

### DIFF
--- a/EventFilter/plugins/BuildFile.xml
+++ b/EventFilter/plugins/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="FWCore/Framework"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/PluginManager"/>
+<use name="DataFormats/CTPPSReco"/>
 <flags EDM_PLUGIN="1"/>

--- a/EventFilter/test/cfg_filter_reduction.py
+++ b/EventFilter/test/cfg_filter_reduction.py
@@ -29,6 +29,7 @@ process.source = cms.Source("PoolSource",
   dropDescendantsOfDroppedBranches = cms.untracked.bool(False),
   inputCommands = cms.untracked.vstring(
     'drop *',
+	 'keep edmTriggerResults_*_*_*',
 	 'keep TotemTriggerCounters_totemTriggerRawToDigi_*_*',
 	 'keep TotemFEDInfos_totemRPRawToDigi_*_*',
 	 'keep TotemRPDigiedmDetSetVector_totemRPRawToDigi_*_*',


### PR DESCRIPTION
Added a keep statement to be able to run the DQM, offline, on top of the filtered AOD. Here 
[triggerResultsBaskets.txt](https://github.com/FrigyesNemes/EventFilter/files/11949181/triggerResultsBaskets.txt)
you can find the extra basket size for 50k filtered events (out of 232k total). 